### PR TITLE
Update classes to use new class syntax

### DIFF
--- a/src/color.temper.md
+++ b/src/color.temper.md
@@ -14,9 +14,10 @@ number of colors that we'll care more about efficiency.
 Given a color, we also want to know what space it's in. Or we might have a list
 of colors in the same space. But here's a single color with a defined space.
 
-    export class Color {
-      public space: Space;
-      public rows: Matrix;
+    export class Color(
+      public space: Space,
+      public rows: Matrix,
+    ) {
 
 TODO Default constructor to check ncols vs space.ncols.
 
@@ -30,13 +31,13 @@ TODO Some consistent representation for opacity?
 
 While `rows` is public, it's sometimes nice to skip through it.
 
-    public get(i: Int, j: Int): Float64 | Bubble { rows[i, j] }
+      public get(i: Int, j: Int): Float64 | Bubble { rows[i, j] }
 
-    public at(i: Int): Float64 | Bubble { rows.at(i) }
+      public at(i: Int): Float64 | Bubble { rows.at(i) }
 
-    public get length(): Int { rows.nrows }
+      public get length(): Int { rows.nrows }
 
-    public get width(): Int { rows.ncols }
+      public get width(): Int { rows.ncols }
 
 ### Conversion
 
@@ -74,13 +75,14 @@ matrices and so on, but this will have to do for now.
 
 TODO How to say that we want to support identity equality on a type?
 
-    export class Space {
+    export class Space(
 
 This class is a simulated enum, although maybe we do want it open beyond spaces
 defined in this library.
 
-      public name: String;
-      public ncols: Int;
+      public name: String,
+      public ncols: Int,
+    ) {
       public toString(): String { name }
 
 Some of the supported spaces here aren't considered by everyone to be true

--- a/src/matrix.temper.md
+++ b/src/matrix.temper.md
@@ -4,7 +4,7 @@ Until we have a builtin backend-connected ND array type, here's a matrix type
 that can efficiently represent lists of color of arbitrary dimensionality. We
 might also want to represent some transforms as matrix operations.
 
-    export class Matrix {
+    export class Matrix(
 
 ## Constructor
 
@@ -18,16 +18,22 @@ Also, an immutable list is passed in so that matrices also are immutable.
 
 TODO Implement nice printing.
 
-      constructor(ncols: Int, values: List<Float64>): Void | Bubble {
+We need to know the number of columns.
+
+      public ncols: Int,
+
+Values is a flat list where each row is made up by a contiguous run of *ncols* entries.
+Keep `values` private in case that makes sense for some backend-connected matrix
+types in the future.
+
+      private values: List<Float64>,
+    ) {
+
+      public nrows: Int = do {
         if (ncols <= 0) { bubble() }
         if (values.length % ncols != 0) { bubble() }
-        this.nrows = values.length / ncols;
-        this.ncols = ncols;
-        this.values = values;
-      }
-
-      public nrows: Int;
-      public ncols: Int;
+        values.length / ncols
+      };
 
 ## Single-Row Factory
 
@@ -154,12 +160,6 @@ TODO Internal stride wrangling to support no-copy transpose?
       )
     }
 
-## Private Members
-
-Keep `values` private in case that makes sense for some backend-connected matrix
-types in the future.
-
-      let values: List<Float64>;
     }
 
 ## Tests


### PR DESCRIPTION
`temper test -b interp` runs clean with these changes.